### PR TITLE
Add sound playback

### DIFF
--- a/webUI/DiagPanel.css
+++ b/webUI/DiagPanel.css
@@ -269,7 +269,12 @@ DIV.diagCaptionRight SPAN:nth-child(1) {
     position:           absolute;
     bottom:             8px;
     left:               8px;
-    right:              16px}
+    right:              180px}
+
+#AudioDiv {
+    position:           absolute;
+    bottom:             8px;
+    right:              8px}
 
 .dumpText {
     white-space:        pre;

--- a/webUI/DiagPanel.html
+++ b/webUI/DiagPanel.html
@@ -109,5 +109,12 @@
     <button id=GoBtn type=button>GO</button>
 </div>
 
+<div id=AudioDiv>
+    Sound:
+    <input id=AudioLines type=text size=15
+        title="Enter a comma seperated list of line numbers."
+        placeholder="Audio Out Lines">
+</div>
+
 </body>
 </html>

--- a/webUI/DiagPanel.js
+++ b/webUI/DiagPanel.js
@@ -42,6 +42,9 @@ class DiagPanel {
         this.boundShutDown = this.shutDown.bind(this);
         this.boundDumpLine = this.dumpLine.bind(this);
         this.boundBPSetChange = this.bpSetChange.bind(this);
+        this.boundSetAudioLines = (ev) => {
+            this.context.devices.sound.lines = this.$$("AudioLines").value.trim();
+        };
         this.boundProcStep = context.processor.step.bind(this.context.processor);
         this.boundProcBP = (ev) => {
             this.context.controlPanel.setComputeSwitch(2);
@@ -341,6 +344,7 @@ class DiagPanel {
         this.$$("BPBtn").addEventListener("click", this.boundProcBP);
         this.$$("GoBtn").addEventListener("click", this.boundProcGo);
         this.$$("StopBtn").addEventListener("click", this.boundProcStop);
+        this.$$("AudioLines").addEventListener("keyup", this.boundSetAudioLines);
         this.window.addEventListener("unload", this.boundShutDown);
 
         this.updatePanel();
@@ -366,6 +370,7 @@ class DiagPanel {
         this.$$("BPBtn").removeEventListener("click", this.boundProcBP);
         this.$$("GoBtn").removeEventListener("click", this.boundProcGo);
         this.$$("StopBtn").removeEventListener("click", this.boundProcStop);
+        this.$$("AudioLines").removeEventListener("keyup", this.boundSetAudioLines);
         if (this.intervalToken) {       // if the display auto-update is running
             this.window.clearInterval(this.intervalToken);  // kill it
             this.intervalToken = 0;

--- a/webUI/DiagPanel.js
+++ b/webUI/DiagPanel.js
@@ -347,6 +347,8 @@ class DiagPanel {
         this.$$("AudioLines").addEventListener("keyup", this.boundSetAudioLines);
         this.window.addEventListener("unload", this.boundShutDown);
 
+        this.$$("AudioLines").value = this.context.devices.sound.lines.join(",");
+        
         this.updatePanel();
         if (!this.intervalToken) {
             this.intervalToken = this.window.setInterval(this.boundUpdatePanel, DiagPanel.displayRefreshPeriod);

--- a/webUI/G15.js
+++ b/webUI/G15.js
@@ -21,6 +21,7 @@ import {Processor} from "../emulator/Processor.js";
 import {PaperTapeReader} from "./PaperTapeReader.js";
 import {PaperTapePunch} from "./PaperTapePunch.js";
 import {Typewriter} from "./Typewriter.js";
+import {Sound} from "./Sound.js";
 
 let globalLoad = (ev) => {
     //let config = new G15SystemConfig(); // system configuration object
@@ -114,7 +115,8 @@ let globalLoad = (ev) => {
         context.devices = {
             "paperTapeReader":          new PaperTapeReader(context),
             "paperTapePunch":           new PaperTapePunch(context),
-            "typewriter":               new Typewriter(context)
+            "typewriter":               new Typewriter(context),
+            "sound":                    new Sound(context)
         }
 
         let timingFactor = Util.drumRPM/Util.defaultRPM;

--- a/webUI/Sound.js
+++ b/webUI/Sound.js
@@ -1,0 +1,117 @@
+export { Sound };
+
+import * as Util from "../emulator/Util.js";
+import { BitField } from "../emulator/BitField.js";
+
+class Sound {
+  //The per line contribution to the audio sigbal (+/-)
+  static LINE_SIGNAL_STRENGTH = 0.01;
+
+  //How often to resample the drum
+  static RESAMPLE_MS = 33;
+
+  constructor(context) {
+    this.drum = context.processor.drum;
+    this.audioCtx = new AudioContext();
+    this._intervalID = false;
+    this._lines = [];
+
+    //Create a buffer for the sound...
+    this.rawSampleBuffer = this.audioCtx.createBuffer(
+      1, //channels
+      Util.longLineSize * Util.wordBits, //One sample per BIT
+      0.5 * Util.longLineSize * Util.wordBits * (Util.drumRPM / 60) //Samples per second
+    );
+
+    //Create audio source using the buffer
+    this.bufferSource = this.audioCtx.createBufferSource();
+    this.bufferSource.buffer = this.rawSampleBuffer;
+    this.bufferSource.loop = true; //Drum spins round and round
+
+    //Connect to the audio context
+    this.gainNode = this.audioCtx.createGain();
+    this.bufferSource.connect(this.gainNode);
+    this.gainNode.connect(this.audioCtx.destination);
+
+    this.bufferSource.start();
+
+    this.enabled = false;
+  }
+
+  updateAudio() {
+    /* Update the audio buffer with values based on the currently tapped lines */
+    if (this._enabled) {
+      const buf = this.rawSampleBuffer.getChannelData(0);
+      buf.fill(0);
+
+      //For every tapped line
+      for (let line of this._lines) {
+        let i = 0; //position in buffer
+        //For every word in the specified line
+        for (let word of this.drum.line[line]) {
+          //For every bit in that word
+          for (let bitNr = 0; bitNr < Util.wordBits; bitNr++) {
+            //Put a value in the buffer
+            if (BitField.bitTest(word, bitNr)) {
+              buf[i] += Sound.LINE_SIGNAL_STRENGTH;
+            } else {
+              buf[i] -= Sound.LINE_SIGNAL_STRENGTH;
+            }
+            i++; //increment the position
+          }
+        }
+      }
+    }
+  }
+
+  set lines(l) {
+    /*Accept either an array of lines, or a comma separated string.*/
+    if (typeof l == "string") {
+      //If string provided, assume comma separated list
+      l = l.split(",");
+      l = l.map((n) => parseInt(n, 10));
+    }
+    //Only valid lines
+    l = l.filter((x) => x >= 0 && x <= 19);
+
+    this._lines = l;
+    this.enabled = this.lines.length > 0;
+  }
+
+  get lines() {
+    /*Return the current set of lines being played*/
+    return this._lines;
+  }
+
+  get enabled() {
+    return this._enabled;
+  }
+
+  set enabled(ena) {
+    /*Set sound output enabled or disabled*/
+    if (ena == this._enabled) {
+      return; //If not changed, bail out.
+    }
+    this._enabled = ena;
+
+    if (this._enabled) {
+      //Enable sound
+
+      //This is gross, but it was quick....
+      //Sample the drum lines into an audio buffer
+      //at a regular, but unsynchronized, rate.
+      this._intervalID = setInterval(
+        this.updateAudio.bind(this),
+        Sound.RESAMPLE_MS
+      );
+      this.audioCtx.resume();
+    } else {
+      //Disable sound
+      if (this._intervalID) {
+        clearInterval(this._intervalID);
+        this._intervalID = false;
+      }
+      this.audioCtx.suspend();
+    }
+  }
+}

--- a/webUI/Sound.js
+++ b/webUI/Sound.js
@@ -5,14 +5,14 @@ import { BitField } from "../emulator/BitField.js";
 
 class Sound {
   //The per line contribution to the audio sigbal (+/-)
-  static LINE_SIGNAL_STRENGTH = 0.3;
+  static LINE_SIGNAL_STRENGTH = 0.1;
 
   //How often to resample the drum
   static RESAMPLE_MS = 11;
 
   constructor(context) {
     this.drum = context.processor.drum;
-    this.audioCtx = new AudioContext();
+
     this._intervalID = false;
     this._lines = [];
 
@@ -20,7 +20,8 @@ class Sound {
   }
 
   async initAudio() {
-    //Connect to the audio context
+    /* Initialize audio and start the Audio Worklet */
+    this.audioCtx = new AudioContext();
     this.gainNode = this.audioCtx.createGain();
     this.gainNode.connect(this.audioCtx.destination);
     await this.audioCtx.audioWorklet.addModule("SoundWorklet.js");

--- a/webUI/Sound.js
+++ b/webUI/Sound.js
@@ -14,9 +14,11 @@ class Sound {
     this.drum = context.processor.drum;
 
     this._intervalID = false;
-    this._lines = [];
-
+    
     this.initAudio();
+
+    this._lines = [];
+    this.enabled = false;
   }
 
   async initAudio() {
@@ -30,9 +32,6 @@ class Sound {
       "SoundWorklet",
     );
     this.workletNode.connect(this.gainNode);
-
-    this.lines = [2,3];
-    this.enabled = true;
   }
 
   updateAudio() {

--- a/webUI/Sound.js
+++ b/webUI/Sound.js
@@ -17,10 +17,13 @@ class Sound {
     this._lines = [];
 
     //Create a buffer for the sound...
+    let bits = 124 * Util.wordBits;
+    let rps = Util.drumRPM / 60;
+    let sps = bits * rps;
     this.rawSampleBuffer = this.audioCtx.createBuffer(
       1, //channels
       Util.longLineSize * Util.wordBits, //One sample per BIT
-      0.5 * Util.longLineSize * Util.wordBits * (Util.drumRPM / 60) //Samples per second
+      sps //Samples per second
     );
 
     //Create audio source using the buffer
@@ -61,6 +64,17 @@ class Sound {
           }
         }
       }
+
+    //Stop the old one
+    this.bufferSource.stop();
+
+    //Create audio source using the buffer
+    this.bufferSource = this.audioCtx.createBufferSource();
+    this.bufferSource.buffer = this.rawSampleBuffer;
+    this.bufferSource.loop = true; //Drum spins round and round
+    this.bufferSource.connect(this.gainNode);
+    this.bufferSource.start();
+
     }
   }
 

--- a/webUI/Sound.js
+++ b/webUI/Sound.js
@@ -34,6 +34,14 @@ class Sound {
     this.workletNode.connect(this.gainNode);
   }
 
+  shutDown() {
+    /* Shuts down the device */
+    this.lines = [];
+    this.workletNode.disconnect();
+    this.gainNode.disconnect();
+    this.audioCtx.close();
+  }
+
   updateAudio() {
     /* Update the audio buffer with values based on the currently tapped lines */
     if (this._enabled) {

--- a/webUI/SoundWorklet.js
+++ b/webUI/SoundWorklet.js
@@ -1,0 +1,64 @@
+import { wordBits, drumRPM } from "../emulator/Util.js";
+
+//Calculate G15 sample rate
+const drumSampleRate = (() => {
+  const drumWords = 124;
+  const bits = drumWords * wordBits;
+  const rps = drumRPM / 60;
+  return bits * rps;
+})();
+
+//Each output sample is this many drum samples
+//Drum sample rate is about 100khz which is a
+//lot higher than most sound cards
+const ratio = drumSampleRate / sampleRate;
+
+/*
+console.log("Drum Sample Rate", drumSampleRate);
+console.log("Audio Context Sample Rate", sampleRate);
+console.log("Ratio", ratio);
+*/
+
+class RandomNoiseProcessor extends AudioWorkletProcessor {
+
+  constructor(...args) {
+    super(...args);
+
+    //The buffer containing the combined audio
+    //from all the lines
+    this.buf = null;
+
+    //The pointer into the buffer where we are
+    //reading
+    this.ptr = 0;
+
+    //Save the buffer sent from the main tread
+    this.port.onmessage = (e) => {
+      const buffer = e.data;
+      this.buf = new Float32Array(buffer);
+    };
+  }
+
+  process(inputs, outputs, parameters) {
+    if (!this.buf){
+      //No data yet
+      return true;
+    }
+
+    outputs[0].forEach((channel) => {
+      let p = this.ptr;
+      for (let i = 0; i < channel.length; i++) {
+        //Increment the pointer by the sample ratio
+        //and wrap it circularly around the buffer
+        p = (p + ratio ) % this.buf.length;
+
+        //Put the right sample to the output
+        channel[i] = this.buf[ Math.floor(p) ];
+      }
+      this.ptr = p;
+    });
+    return true;
+  }
+}
+
+registerProcessor("SoundWorklet", RandomNoiseProcessor);


### PR DESCRIPTION
This PR emulates Music Playback

User Project #41 by Raymond Walls of the Bendix Radio Division presents a method of connecting the RW heads of the drum to an audio amplifier to play back music. Memory lines (2 & 3 in his demo, 19 in others) are connected to the stereo, and then notes -strings of bits approximating square waves of various frequencies - are block copied from other lines to these output lines to be played.

https://rbk.delosent.com/allq/Q8430.pdf

This update was tested on Chrome and Firefox and uses audio worklets from the web audio API to generate and playback sound.